### PR TITLE
Use version defines to allow settings to know if addressables installed

### DIFF
--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/Eflatun.SceneReference.Editor.asmdef
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/Eflatun.SceneReference.Editor.asmdef
@@ -14,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.addressables",
+            "expression": "1.1",
+            "define": "UNITY_PACKAGE_ADDRESSABLES"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SettingsManager.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SettingsManager.cs
@@ -31,6 +31,17 @@ namespace Eflatun.SceneReference.Editor
 
         [SettingsProvider]
         private static SettingsProvider CreateUserSettingsProvider() => new UserSettingsProvider(SettingsMenuPath, Settings, new[] { ContainingAssembly }, SettingsScope.Project);
+        
+        private static bool IsAddressablesEnabled
+        {
+            get
+            {
+                #if UNITY_PACKAGE_ADDRESSABLES
+                    return true;
+                #endif
+                return false;
+            }
+        }
 
         /// <summary>
         /// Settings regarding the scene GUID to path map.


### PR DESCRIPTION
by using asmdef version defines, the package can identify if end-user has unity's addressable package installed.  
This allows for adding Addressable-only advanced features that compile only if the addressables package is present.  