### PR TITLE
update readme to fix menu item path

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Running the generator has no side-effects.
 
 ### Via Menu Item
 
-You can trigger the generator via a menu item. Find it under `Eflatun/Scene Reference/Run Scene GUID to Path Map Generator`:
+You can trigger the generator via a menu item. Find it under `Tools/Eflatun/Scene Reference/Run Scene GUID to Path Map Generator`:
 
 ![.assets/generator_menu.png](.assets/generator_menu.png)
 


### PR DESCRIPTION
menu item to "Run Scene GUID to Path Map Generator" describes wrong path.  latest version has that menu item under "Tools".