### PR TITLE
docs: replace ScenePath with Path in example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ using Eflatun.SceneReference;
 
 // You can access these anytime, anywhere
 var sceneGuid = mySceneReference.AssetGuidHex;
-var scenePath = mySceneReference.ScenePath;
+var scenePath = mySceneReference.Path;
 var sceneBuildIndex = mySceneReference.BuildIndex;
 var sceneName = mySceneReference.Name;
 


### PR DESCRIPTION
Cannot resolve symbol 'ScenePath'

Confirmed this locally using `com.eflatun.scenereference` version 1.5.0

Related source: https://github.com/starikcetin/Eflatun.SceneReference/blob/main/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneReference.cs#L126-L147