### PR TITLE
refactor!: make constructors and factory methods validate arguments and throw exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Breaking Changes
+- Constructors and factory methods of `SceneReference` now validate their arguments and throw exceptions of type `SceneReferenceCreationException` if they are invalid. Note that the default constructor always creates an empty instance, but it never throws.
+
 ### Added
 - `SceneReference` now supports custom XML serialization via `System.Xml`.
 - `SceneGuidToPathMapProvider` now also provides a path to GUID map, which is inversely equivalent to the already existing GUID to path map.
+- `SceneReferenceCreationException`: Thrown when something goes wrong during the creation of a `SceneReference`.
 
 ### Changed
 - `SceneReference` now implements serialization interfaces explicitly. This means serialization implementations are no longer exposed as `public`.

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneReference.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneReference.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Runtime.Serialization;
 using System.Xml;
 using System.Xml.Schema;
@@ -28,14 +27,27 @@ namespace Eflatun.SceneReference
         /// </summary>
         /// <param name="scenePath">Path of the scene to reference.</param>
         /// <returns>A new <see cref="SceneReference"/>.</returns>
-        /// <remarks>
-        /// This factory method does NOT validate the given path. If it is invalid, then the created
-        /// <see cref="SceneReference"/> will also be invalid.
-        /// </remarks>
+        /// <exception cref="SceneReferenceCreationException">Throws if the given path is null or whitespace.</exception>
+        /// <exception cref="SceneReferenceCreationException">Throws if the given path is not found in the Scene Path to GUID map.</exception>
         public static SceneReference FromScenePath(string scenePath)
         {
-            var guid = SceneGuidToPathMapProvider.SceneGuidToPathMap.SingleOrDefault(x => x.Value == scenePath).Key;
-            return new SceneReference(guid);
+            if (string.IsNullOrWhiteSpace(scenePath))
+            {
+                throw new SceneReferenceCreationException(
+                    $"Given path is null or whitespace. Path: '{scenePath}'" +
+                    "\nTo fix this, make sure you provide the path of a valid scene.");
+            }
+
+            if (!SceneGuidToPathMapProvider.ScenePathToGuidMap.TryGetValue(scenePath, out var sceneGuid))
+            {
+                throw new SceneReferenceCreationException(
+                    $"Given path is not found in the scene GUID to path map. Path: '{scenePath}'"
+                    + "\nThis can happen for these reasons:"
+                    + "\n1. The asset at the given path either doesn't exist or is not a scene. To fix this, make sure you provide the path of a valid scene."
+                    + "\n2. The scene GUID to path map is outdated. To fix this, you can either manually run the generator, or enable generation triggers. It is highly recommended to keep all the generation triggers enabled.");
+            }
+
+            return new SceneReference(sceneGuid);
         }
 
         // GUID hex of an invalid asset contains all zeros. A GUID hex has 32 chars.
@@ -45,8 +57,9 @@ namespace Eflatun.SceneReference
         [SerializeField] internal string sceneAssetGuidHex;
 
         /// <summary>
-        /// Creates a new <see cref="SceneReference"/> which is empty, and subsequently invalid.
+        /// Creates a new empty <see cref="SceneReference"/>.
         /// </summary>
+        /// <remarks>This constructor never throws.</remarks>
         public SceneReference()
         {
             // This parameterless constructor is required for the XML serialization.
@@ -60,18 +73,40 @@ namespace Eflatun.SceneReference
         /// Creates a new <see cref="SceneReference"/> which references the scene that has the given GUID.
         /// </summary>
         /// <param name="sceneAssetGuidHex">GUID of the scene to reference.</param>
-        /// <remarks>
-        /// This constructor does NOT validate the given GUID. If it is invalid, then the created
-        /// <see cref="SceneReference"/> will also be invalid.
-        /// </remarks>
+        /// <exception cref="SceneReferenceCreationException">Throws if the given GUID is null or empty.</exception>
+        /// <exception cref="SceneReferenceCreationException">Throws if the given GUID is not found in the Scene GUID to Path map.</exception>
+        /// <exception cref="SceneReferenceCreationException">(Editor-only) Throws if the asset is not found at the path that the GUID corresponds to.</exception>
         public SceneReference(string sceneAssetGuidHex)
         {
+            if (string.IsNullOrWhiteSpace(sceneAssetGuidHex))
+            {
+                throw new SceneReferenceCreationException(
+                    $"Given GUID is null or whitespace. GUID: '{sceneAssetGuidHex}'." +
+                    "\nTo fix this, make sure you provide the GUID of a valid scene.");
+            }
+
+            if (!SceneGuidToPathMapProvider.SceneGuidToPathMap.TryGetValue(sceneAssetGuidHex, out var scenePath))
+            {
+                throw new SceneReferenceCreationException(
+                    $"Given GUID is not found in the scene GUID to path map. GUID: '{sceneAssetGuidHex}'"
+                    + "\nThis can happen for these reasons:"
+                    + "\n1. The asset with the given GUID either doesn't exist or is not a scene. To fix this, make sure you provide the GUID of a valid scene."
+                    + "\n2. The scene GUID to path map is outdated. To fix this, you can either manually run the generator, or enable generation triggers. It is highly recommended to keep all the generation triggers enabled.");
+            }
+
             this.sceneAssetGuidHex = sceneAssetGuidHex;
 
 #if UNITY_EDITOR
-            sceneAsset = SceneGuidToPathMapProvider.SceneGuidToPathMap.TryGetValue(sceneAssetGuidHex, out var scenePath)
-                ? AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(scenePath)
-                : null;
+            var foundAsset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(scenePath);
+
+            if (!foundAsset)
+            {
+                throw new SceneReferenceCreationException(
+                    $"The given GUID was found in the map, but the scene asset at the corresponding path could not be loaded. Path: '{scenePath}'."
+                    + "\nThis can happen due to an outdated scene GUID to path map retaining scene assets that no longer exist. To fix this, you can either manually run the generator, or enable generation triggers. It is highly recommended to keep all the generation triggers enabled.");
+            }
+
+            sceneAsset = foundAsset;
 #endif // UNITY_EDITOR
         }
 
@@ -80,17 +115,32 @@ namespace Eflatun.SceneReference
         /// Creates a new <see cref="SceneReference"/> which references the given scene asset.
         /// </summary>
         /// <param name="sceneAsset">The asset of the scene to reference.</param>
-        /// <remarks>
-        /// This constructor is for editor-use only. Do NOT use it in runtime code.<p/>
-        /// This constructor does NOT validate the given asset. If it is invalid, then the created
-        /// <see cref="SceneReference"/> will also be invalid.
-        /// </remarks>
+        /// <exception cref="SceneReferenceCreationException">Throws if the given asset is null.</exception>
+        /// <exception cref="SceneReferenceCreationException">Throws if the GUID of the given asset cannot be retrieved.</exception>
+        /// <exception cref="SceneReferenceCreationException">Throws if the Scene GUID to Path map does not contain the GUID of the given asset.</exception>
+        /// <remarks>This constructor is for editor-use only. Do NOT use it in runtime code.</remarks>
         public SceneReference(UnityEngine.Object sceneAsset)
         {
-            sceneAssetGuidHex = AssetDatabase.TryGetGUIDAndLocalFileIdentifier(sceneAsset, out var guid, out long _)
-                ? guid
-                : AllZeroGuidHex;
+            if (!sceneAsset)
+            {
+                throw new SceneReferenceCreationException("Given scene asset is null. To fix this, make sure you provide a valid scene asset.");
+            }
 
+            if (!AssetDatabase.TryGetGUIDAndLocalFileIdentifier(sceneAsset, out var guid, out long _))
+            {
+                throw new SceneReferenceCreationException("Could not retrieve the GUID of the given scene asset. This usually indicates an invalid asset. To fix this, make sure you provide a valid scene asset.");
+            }
+
+            if (!SceneGuidToPathMapProvider.SceneGuidToPathMap.ContainsKey(guid))
+            {
+                throw new SceneReferenceCreationException(
+                    $"The GUID of the given scene asset is not found in the scene GUID to path map. GUID: '{guid}'"
+                    + "\nThis can happen for these reasons:"
+                    + "\n1. Given asset either doesn't exist or is not a scene. To fix this, make sure you provide a valid scene asset."
+                    + "\n2. The scene GUID to path map is outdated. To fix this, you can either manually run the generator, or enable generation triggers. It is highly recommended to keep all the generation triggers enabled.");
+            }
+
+            sceneAssetGuidHex = guid;
             this.sceneAsset = sceneAsset;
         }
 #endif // UNITY_EDITOR

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneReference.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneReference.cs
@@ -149,8 +149,16 @@ namespace Eflatun.SceneReference
         /// Used by <see cref="ISerializable"/> for custom JSON and Binary serialization support.
         /// </summary>
         protected SceneReference(SerializationInfo info, StreamingContext context)
-            : this(info.GetString("sceneAssetGuidHex"))
         {
+            var deserializedGuid = info.GetString("sceneAssetGuidHex");
+            sceneAssetGuidHex = deserializedGuid;
+
+#if UNITY_EDITOR
+            if (SceneGuidToPathMapProvider.SceneGuidToPathMap.TryGetValue(deserializedGuid, out var scenePath))
+            {
+                sceneAsset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(scenePath);
+            }
+#endif // UNITY_EDITOR
         }
 
         /// <summary>

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneReferenceCreationException.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneReferenceCreationException.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Runtime.Serialization;
+using JetBrains.Annotations;
+
+namespace Eflatun.SceneReference
+{
+    /// <summary>
+    /// Thrown when something goes wrong during the creation of a <see cref="SceneReference"/>.
+    /// </summary>
+    [PublicAPI]
+    [Serializable]
+    public class SceneReferenceCreationException : SceneReferenceException
+    {
+        private static string PrefixMessage(string message) => $"An exception occured during the creation of a {nameof(SceneReference)}: {message}";
+
+        internal SceneReferenceCreationException(string message) : base(PrefixMessage(message))
+        {
+        }
+
+        internal SceneReferenceCreationException(string message, Exception inner) : base(PrefixMessage(message), inner)
+        {
+        }
+
+        private protected SceneReferenceCreationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneReferenceCreationException.cs.meta
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneReferenceCreationException.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4fb66ffbdd684db2aa301e767009e62d
+timeCreated: 1677264589

--- a/README.md
+++ b/README.md
@@ -440,8 +440,8 @@ var fromSceneAsset = new SceneReference(sceneAsset);
 ```
 
 **Warnings:**
-- Constructors and the factory methods do NOT validate their arguments. If the given arguments are invalid, then the created `SceneReference` instance will also be invalid.
-- The default constructor always creates an empty and subsequently invalid instance.
+- Constructors and factory methods validate their arguments and throw exceptions of type `SceneReferenceCreationException` if they are invalid.
+- The default constructor always creates an empty instance, but it never throws.
 - The constructor that accepts a scene asset of type `UnityEngine.Object` is for Editor-use only. Do NOT use it in runtime code.
 
 # Exceptions
@@ -463,6 +463,14 @@ Thrown if a `SceneReference` is invalid. This can happen for these reasons:
 2. The Scene GUID to Path Map is outdated. To fix this, you can either manually run the map generator, or enable all generation triggers. It is highly recommended to keep all the generation triggers enabled.
 
 You can avoid it by checking `IsSafeToUse` (recommended) or `IsInSceneGuidToPathMap`.
+
+## `SceneReferenceCreationException`
+
+Thrown when something goes wrong during the creation of a `SceneReference`. 
+
+It can happen for many different reasons. 
+
+The exception message contains the particular reason and suggestions on how to fix it.
 
 ## `SceneReferenceInternalException`
 


### PR DESCRIPTION
Closes #38

BREAKING CHANGE: Constructors and factory methods used to not throw, and just produce invalid SceneReferences. Now they validate their arguments and throw exceptions of type SceneReferenceCreationException if they are invalid.