### PR TITLE
fix: workaround unity bug while drawing our settings in 2022.3.4f1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Implemented workaround for a Unity bug that caused our settings page to throw exceptions and not display in Unity `2022.3.4f1`.
 
 
 

--- a/Eflatun.SceneReference/Assets/Development Utils/Editor/Eflatun.SceneReference.DevelopmentUtils.Editor.asmdef
+++ b/Eflatun.SceneReference/Assets/Development Utils/Editor/Eflatun.SceneReference.DevelopmentUtils.Editor.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "GUID:a552348fa1f04b9fba27401570eefbfb",
         "GUID:69518689ee43e43439e85b2232f66f27",
-        "GUID:caca889fed6088d40b22c2d7e2909c31"
+        "GUID:caca889fed6088d40b22c2d7e2909c31",
+        "GUID:49818357e697641afb75d2f8acaf1861"
     ],
     "includePlatforms": [
         "Editor"

--- a/Eflatun.SceneReference/Assets/Development Utils/Editor/SettingsManipulator.cs
+++ b/Eflatun.SceneReference/Assets/Development Utils/Editor/SettingsManipulator.cs
@@ -1,0 +1,29 @@
+﻿using Eflatun.SceneReference.Editor;
+using UnityEditor;
+
+namespace Eflatun.SceneReference.DevelopmentUtils.Editor
+{
+    public class SettingsManipulator : EditorWindow
+    {
+        [MenuItem("Tools/" + Constants.MenuPrefixBase + "/_Dev/Settings Manipulator")]
+        public static void Display()
+        {
+            GetWindow<SettingsManipulator>();
+        }
+
+        private void OnGUI()
+        {
+            // Draw GenerationTriggers field.
+            {
+                var oldPublic = SettingsManager.SceneDataMaps.GenerationTriggers.value;
+                var oldInternal = (InternalSceneDataMapsGeneratorTriggers)oldPublic;
+                var newInternal = EditorGUILayout.EnumFlagsField("Generation Triggers", oldInternal);
+                var newPublic = (SceneDataMapsGeneratorTriggers)newInternal;
+                if (newPublic != oldPublic)
+                {
+                    SettingsManager.SceneDataMaps.GenerationTriggers.value = newPublic;
+                }
+            }
+        }
+    }
+}

--- a/Eflatun.SceneReference/Assets/Development Utils/Editor/SettingsManipulator.cs.meta
+++ b/Eflatun.SceneReference/Assets/Development Utils/Editor/SettingsManipulator.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b8f6f42f8fa64fdbb87974d8c5e1a118
+timeCreated: 1690042495

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/AssemblyInfo.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine.Scripting;
+﻿using System.Runtime.CompilerServices;
+using UnityEngine.Scripting;
+
+[assembly: InternalsVisibleTo("Eflatun.SceneReference.DevelopmentUtils.Editor")]
 
 // Always link to make sure InitializeOnLoad methods don't get stripped away
 [assembly: AlwaysLinkAssembly]

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneDataMapsGeneratorTriggers.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneDataMapsGeneratorTriggers.cs
@@ -3,6 +3,8 @@ using JetBrains.Annotations;
 
 namespace Eflatun.SceneReference.Editor
 {
+    // IMPORTANT: Keep SceneDataMapsGeneratorTriggers and InternalSceneDataMapsGeneratorTriggers in sync at all times.
+    
     /// <summary>
     /// Identifiers for places that trigger <see cref="SceneDataMapsGenerator"/>.
     /// </summary>
@@ -13,6 +15,19 @@ namespace Eflatun.SceneReference.Editor
         None = 0,
         All = ~0,
 
+        AfterSceneAssetChange = 1 << 0,
+        BeforeEnterPlayMode = 1 << 1,
+        BeforeBuild = 1 << 2,
+        AfterPackagesResolve = 1 << 3,
+        AfterAddressablesChange = 1 << 4,
+    }
+    
+    /// <summary>
+    /// Same as <see cref="SceneDataMapsGeneratorTriggers"/>, but without the <c>All</c> and <c>None</c> values.
+    /// </summary>
+    [Flags]
+    internal enum InternalSceneDataMapsGeneratorTriggers
+    {
         AfterSceneAssetChange = 1 << 0,
         BeforeEnterPlayMode = 1 << 1,
         BeforeBuild = 1 << 2,

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SettingsManager.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SettingsManager.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using UnityEditor;
 using UnityEditor.SettingsManagement;
 using Newtonsoft.Json;
+using UnityEngine;
 
 namespace Eflatun.SceneReference.Editor
 {
@@ -60,7 +61,6 @@ namespace Eflatun.SceneReference.Editor
             /// <inheritdoc cref="SettingsManager"/>
             /// </remarks>
             /// <seealso cref="IsGenerationTriggerEnabled"/>
-            [field: UserSetting(CategoryName, "Generation Triggers", "Controls when the scene data maps get regenerated.\n\n• AAfter Scene Asset Change: Regenerate the maps every time a scene asset changes (delete, create, move, rename).\n\n• Before Enter Play Mode: Regenerate the maps before entering play mode in the editor.\n\n• Before Build: Regenerate the maps before a build.\n\n• After Packages Resolve: Regenerate the maps after UPM packages are resolved.\n\n• After Addressables Change: Regenerate the maps after addressable group entries change. Only relevant if you have addressables support enabled.\n\nIt is recommended that you leave this option at 'All' unless you are debugging something. Failure to generate the maps when needed can result in broken scene references in runtime.\n\nNote: 'All' and 'Everything' are the same thing. They both represent all triggers.")]
             public static ProjectSetting<SceneDataMapsGeneratorTriggers> GenerationTriggers { get; }
                 = new ProjectSetting<SceneDataMapsGeneratorTriggers>("SceneDataMaps.GenerationTriggers", SceneDataMapsGeneratorTriggers.All);
 
@@ -90,6 +90,23 @@ namespace Eflatun.SceneReference.Editor
             /// <seealso cref="GenerationTriggers"/>
             public static bool IsGenerationTriggerEnabled(SceneDataMapsGeneratorTriggers trigger) =>
                 GenerationTriggers.value.IncludesFlag(trigger);
+            
+            [UserSettingBlock(CategoryName)]
+            private static void Draw(string searchContext)
+            {
+                // Draw GenerationTriggers field.
+                {
+                    var oldPublic = GenerationTriggers.value;
+                    var oldInternal = (InternalSceneDataMapsGeneratorTriggers)oldPublic;
+                    var label = new GUIContent("Generation Triggers", "Controls when the scene data maps get regenerated.\n\n• After Scene Asset Change: Regenerate the maps every time a scene asset changes (delete, create, move, rename).\n\n• Before Enter Play Mode: Regenerate the maps before entering play mode in the editor.\n\n• Before Build: Regenerate the maps before a build.\n\n• After Packages Resolve: Regenerate the maps after UPM packages are resolved.\n\n• After Addressables Change: Regenerate the maps after addressable group entries change. Only relevant if you have addressables support enabled.\n\nIt is recommended that you leave this option at 'All' unless you are debugging something. Failure to generate the maps when needed can result in broken scene references in runtime.\n\nNote: 'All' and 'Everything' are the same thing. They both represent all triggers.");
+                    var newInternal = EditorGUILayout.EnumFlagsField(label, oldInternal);
+                    var newPublic = (SceneDataMapsGeneratorTriggers)newInternal;
+                    if (newPublic != oldPublic)
+                    {
+                        GenerationTriggers.value = newPublic;
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SettingsManager.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SettingsManager.cs
@@ -61,6 +61,7 @@ namespace Eflatun.SceneReference.Editor
             /// <inheritdoc cref="SettingsManager"/>
             /// </remarks>
             /// <seealso cref="IsGenerationTriggerEnabled"/>
+            [field: UserSetting]
             public static ProjectSetting<SceneDataMapsGeneratorTriggers> GenerationTriggers { get; }
                 = new ProjectSetting<SceneDataMapsGeneratorTriggers>("SceneDataMaps.GenerationTriggers", SceneDataMapsGeneratorTriggers.All);
 
@@ -100,6 +101,7 @@ namespace Eflatun.SceneReference.Editor
                     var oldInternal = (InternalSceneDataMapsGeneratorTriggers)oldPublic;
                     var label = new GUIContent("Generation Triggers", "Controls when the scene data maps get regenerated.\n\n• After Scene Asset Change: Regenerate the maps every time a scene asset changes (delete, create, move, rename).\n\n• Before Enter Play Mode: Regenerate the maps before entering play mode in the editor.\n\n• Before Build: Regenerate the maps before a build.\n\n• After Packages Resolve: Regenerate the maps after UPM packages are resolved.\n\n• After Addressables Change: Regenerate the maps after addressable group entries change. Only relevant if you have addressables support enabled.\n\nIt is recommended that you leave this option at 'All' unless you are debugging something. Failure to generate the maps when needed can result in broken scene references in runtime.\n\nNote: 'All' and 'Everything' are the same thing. They both represent all triggers.");
                     var newInternal = EditorGUILayout.EnumFlagsField(label, oldInternal);
+                    SettingsGUILayout.DoResetContextMenuForLastRect(GenerationTriggers);
                     var newPublic = (SceneDataMapsGeneratorTriggers)newInternal;
                     if (newPublic != oldPublic)
                     {

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/AssemblyInfo.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/AssemblyInfo.cs
@@ -1,11 +1,9 @@
 ﻿using System.Runtime.CompilerServices;
 using UnityEngine.Scripting;
 
-// Make internals visible to the Editor assembly
 [assembly: InternalsVisibleTo("Eflatun.SceneReference.Editor")]
-
-// Make internals visible to the runtime tests assembly
 [assembly: InternalsVisibleTo("Eflatun.SceneReference.Tests.Runtime")]
+[assembly: InternalsVisibleTo("Eflatun.SceneReference.DevelopmentUtils.Editor")]
 
 // Always link to make sure RuntimeInitializeOnLoadMethod methods don't get stripped away
 [assembly: AlwaysLinkAssembly]


### PR DESCRIPTION
Fixes #59

The root cause is a Unity bug in `2022.3.4f1`. `EnumFlagsField` misbehaves when there is an entry with value `-1` (`All`). This PR implements a workaround by introducing another enum for internal usage that has the exact same entries but without the `All` and `None` values.

This PR should be reverted after Unity fixes the aforementioned bug.