### PR TITLE
fix: trying to access addressable settings while editor is compiling

### DIFF
--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/MapGeneratorTriggers/AddressablesChangeListener.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/MapGeneratorTriggers/AddressablesChangeListener.cs
@@ -11,6 +11,21 @@ namespace Eflatun.SceneReference.Editor.MapGeneratorTriggers
     {
         static AddressablesChangeListener()
         {
+            EditorApplication.update += DelayedInitialization;
+        }
+
+        /// <summary>
+        /// Wait for Editor to finish compiling before initializing. Otherwise AddressableAssetSettingsDefaultObject.Settings returns null.
+        /// </summary>
+        private static void DelayedInitialization()
+        {
+            if (EditorApplication.isCompiling || EditorApplication.isUpdating)
+            {
+                return;
+            }
+
+            EditorApplication.update -= DelayedInitialization; 
+            //now its safe to initialize:
             AddressableAssetSettingsDefaultObject.Settings.OnModification += OnAddressablesChange;
         }
 

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/MapGeneratorTriggers/SceneAssetPostprocessor.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/MapGeneratorTriggers/SceneAssetPostprocessor.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Eflatun.SceneReference.Editor.Utility;
 using UnityEditor;
 
@@ -16,14 +16,31 @@ namespace Eflatun.SceneReference.Editor.MapGeneratorTriggers
 
             if (hasSceneChange)
             {
-                if (SettingsManager.SceneDataMaps.IsGenerationTriggerEnabled(SceneDataMapsGeneratorTriggers.AfterSceneAssetChange))
-                {
-                    SceneDataMapsGenerator.Run();
-                }
-                else
-                {
-                    EditorLogger.Warn($"Skipping scene data maps generation after scene asset changes. It is recommended to enable map generation after scene asset changes, as an outdated map can result in broken scene references in runtime. You can enable it in {SettingsManager.SettingsMenuPathForDisplay}.");
-                }
+                //Schedule a Map generation
+                EditorApplication.update += DelayedMapGeneration;
+            }
+        }
+
+        /// <summary>
+        /// Waits for Unity editor to finish compiling.
+        /// When that condition is met, unsubscribes from unity editor update and refreshes ScenesDataMaps.
+        /// </summary>
+        private static void DelayedMapGeneration()
+        {
+            if (EditorApplication.isCompiling || EditorApplication.isUpdating)
+            {
+                return;
+            }
+            EditorApplication.update -= DelayedMapGeneration;
+            
+
+            if (SettingsManager.SceneDataMaps.IsGenerationTriggerEnabled(SceneDataMapsGeneratorTriggers.AfterSceneAssetChange))
+            {
+                SceneDataMapsGenerator.Run();
+            }
+            else
+            {
+                EditorLogger.Warn($"Skipping scene data maps generation after scene asset changes. It is recommended to enable map generation after scene asset changes, as an outdated map can result in broken scene references in runtime. You can enable it in {SettingsManager.SettingsMenuPathForDisplay}.");
             }
         }
     }


### PR DESCRIPTION
Its documented limitation of AddressableAssetSettingsDefaultObject.Settings will return null if being accessed while Editor is compiling or updating.  This provides a workaround to remove the null Settings error. 