### PR TITLE
fix: EditorStyles.iconButton not available in older versions of unity

### DIFF
--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
@@ -164,7 +164,14 @@ namespace Eflatun.SceneReference.Editor
 
                 // TODO: we should ship our own icon to prevent this breaking in the future
                 var settingsIcon = EditorGUIUtility.IconContent("SettingsIcon");
-                var toolboxButton = GUI.Button(toolboxButtonRect, settingsIcon, EditorStyles.iconButton);
+                
+                #if UNITY_2022_1_OR_NEWER
+                    var toolboxButtonStyle = EditorStyles.iconButton;
+                #else
+                    var toolboxButtonStyle = EditorStyles.miniButton;
+                #endif
+                
+                var toolboxButton = GUI.Button(toolboxButtonRect, settingsIcon, toolboxButtonStyle);
                 if (toolboxButton)
                 {
                     var toolboxPopupWindow = CreateToolboxPopupWindow();


### PR DESCRIPTION
simple fix for older versions of editor not having iconButton editor style  (to resolve this open issue: #74) 