### PR TITLE
fix: toolbox button backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Backwards compatibility: Use `EditorStyles.miniButton` instead of non-existent `EditorStyles.iconButton` for Unity versions earlier than 2022.1.
 
 
 

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
@@ -165,11 +165,11 @@ namespace Eflatun.SceneReference.Editor
                 // TODO: we should ship our own icon to prevent this breaking in the future
                 var settingsIcon = EditorGUIUtility.IconContent("SettingsIcon");
                 
-                #if UNITY_2022_1_OR_NEWER
-                    var toolboxButtonStyle = EditorStyles.iconButton;
-                #else
-                    var toolboxButtonStyle = EditorStyles.miniButton;
-                #endif
+#if UNITY_2022_1_OR_NEWER
+                var toolboxButtonStyle = EditorStyles.iconButton;
+#else
+                var toolboxButtonStyle = EditorStyles.miniButton;
+#endif
                 
                 var toolboxButton = GUI.Button(toolboxButtonRect, settingsIcon, toolboxButtonStyle);
                 if (toolboxButton)

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -164,14 +164,14 @@ namespace Eflatun.SceneReference.Editor
 
                 // TODO: we should ship our own icon to prevent this breaking in the future
                 var settingsIcon = EditorGUIUtility.IconContent("SettingsIcon");
-                
+
 #if UNITY_2022_1_OR_NEWER
                 var toolboxButtonStyle = EditorStyles.iconButton;
 #else
                 var toolboxButtonStyle = EditorStyles.miniButton;
                 toolboxButtonStyle.padding = new RectOffset(1, 1, 1, 1);
 #endif
-                
+
                 var toolboxButton = GUI.Button(toolboxButtonRect, settingsIcon, toolboxButtonStyle);
                 if (toolboxButton)
                 {

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
@@ -164,7 +164,14 @@ namespace Eflatun.SceneReference.Editor
 
                 // TODO: we should ship our own icon to prevent this breaking in the future
                 var settingsIcon = EditorGUIUtility.IconContent("SettingsIcon");
-                var toolboxButton = GUI.Button(toolboxButtonRect, settingsIcon, EditorStyles.iconButton);
+                
+                #if UNITY_2022_1_OR_NEWER
+                    var toolboxButtonStyle = EditorStyles.iconButton;
+                #else
+                    var toolboxButtonStyle = EditorStyles.miniButton;
+                #endif
+                
+                var toolboxButton = GUI.Button(toolboxButtonRect, settingsIcon, toolboxButtonStyle);
                 if (toolboxButton)
                 {
                     var toolboxPopupWindow = CreateToolboxPopupWindow();

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -169,6 +169,7 @@ namespace Eflatun.SceneReference.Editor
                 var toolboxButtonStyle = EditorStyles.iconButton;
 #else
                 var toolboxButtonStyle = EditorStyles.miniButton;
+                toolboxButtonStyle.padding = new RectOffset(1, 1, 1, 1);
 #endif
                 
                 var toolboxButton = GUI.Button(toolboxButtonRect, settingsIcon, toolboxButtonStyle);

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
@@ -165,6 +165,7 @@ namespace Eflatun.SceneReference.Editor
                 // TODO: we should ship our own icon to prevent this breaking in the future
                 var settingsIcon = EditorGUIUtility.IconContent("SettingsIcon");
 
+// Backwards compatibility (https://github.com/starikcetin/Eflatun.SceneReference/issues/74)
 #if UNITY_2022_1_OR_NEWER
                 var toolboxButtonStyle = EditorStyles.iconButton;
 #else


### PR DESCRIPTION
Supersedes #75
Closes #74