### PR TITLE
fix: work around addressable settings delayed initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Prevent `Scene GUID to path map file not found!` errors and null reference exceptions in `SceneAssetPostprocessor` if the scene GUID to path map file is missing.
-
+- Prevent null reference exceptions at project launch due to addressables settings not being loaded yet.
 
 
 ## [3.2.0] - 2023-11-20

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/MapGeneratorTriggers/AddressablesChangeListener.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/MapGeneratorTriggers/AddressablesChangeListener.cs
@@ -1,54 +1,16 @@
 ﻿#if ESR_ADDRESSABLES
 
-using Eflatun.SceneReference.Editor.Utility;
-using System.Linq;
 using UnityEditor;
-using UnityEditor.AddressableAssets;
 using UnityEditor.AddressableAssets.Settings;
-using UnityEngine;
 
 namespace Eflatun.SceneReference.Editor.MapGeneratorTriggers
 {
     [InitializeOnLoad]
     internal class AddressablesChangeListener : AssetPostprocessor
     {
-        private static bool _isSubscribed;
-
         static AddressablesChangeListener()
         {
-            if (AddressableAssetSettingsDefaultObject.SettingsExists)
-            {
-                if (!_isSubscribed)
-                {
-                    AddressableAssetSettingsDefaultObject.Settings.OnModification += OnAddressablesChange;
-                    _isSubscribed = true;
-                }
-            }
-            else
-            {
-                EditorLogger.Warn("Addressables settings not found. Skipping subscribing to addressables changes.");
-            }
-        }
-
-        private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
-        {
-            if (AddressableAssetSettingsDefaultObject.SettingsExists)
-            {
-                if (!_isSubscribed)
-                {
-                    EditorLogger.Debug("Found addressables settings. Subscribing to addressables changes.");
-                    AddressableAssetSettingsDefaultObject.Settings.OnModification += OnAddressablesChange;
-                    _isSubscribed = true;
-                }
-            }
-            else
-            {
-                if (_isSubscribed)
-                {
-                    EditorLogger.Warn("Lost addressables settings. Unsubscribing from addressables changes.");
-                    _isSubscribed = false;
-                }
-            }
+            AddressableAssetSettings.OnModificationGlobal += OnAddressablesChange;
         }
 
         private static void OnAddressablesChange(AddressableAssetSettings s, AddressableAssetSettings.ModificationEvent e, object o)


### PR DESCRIPTION
Closes #65
Supersedes #66

Turns out Addressables provides a global event listening mechanism which doesn't require us to reach for the default settings file. This solution also doesn't require any delays which might cause unpredictable behaviour in batchmode builds.

---

TODO:
- [ ] Changelog