### PR TITLE
fix: handle all guids case insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - All GUIDs are now compared case-insensitively:
   - Provider dictionaries are constructed with `StringComparer.OrdinalIgnoreCase`.
+  - Property drawer finds the current scene-in-build entry with `StringComparer.OrdinalIgnoreCase`.
 
 ### Optimised
 - Eliminated GC allocations in `IsValidGuid`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- All GUIDs are now compared case-insensitively:
+  - Provider dictionaries are constructed with `StringComparer.OrdinalIgnoreCase`.
 
 ### Optimised
 - Eliminated GC allocations in `IsValidGuid`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - All GUIDs are now compared case-insensitively:
   - Provider dictionaries are constructed with `StringComparer.OrdinalIgnoreCase`.
   - Property drawer finds the current scene-in-build entry with `StringComparer.OrdinalIgnoreCase`.
+  - `Enable in Build` tool finds the scene-in-build entry with `StringComparer.OrdinalIgnoreCase`.
 
 ### Optimised
 - Eliminated GC allocations in `IsValidGuid`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Provider dictionaries are constructed with `StringComparer.OrdinalIgnoreCase`.
   - Property drawer finds the current scene-in-build entry with `StringComparer.OrdinalIgnoreCase`.
   - `Enable in Build` tool finds the scene-in-build entry with `StringComparer.OrdinalIgnoreCase`.
+  - Utility ignores in list mode now compare scene GUIDs with `StringComparer.OrdinalIgnoreCase`.
 
 ### Optimised
 - Eliminated GC allocations in `IsValidGuid`.

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/EqualityAndHashCode/SceneReferenceEqualityTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/EqualityAndHashCode/SceneReferenceEqualityTests.cs
@@ -66,6 +66,28 @@ namespace Eflatun.SceneReference.Tests.Runtime.EqualityAndHashCode
             CreateInvalid(conceptionTypeB, invalidReasonB)
         );
 
+        [Test]
+        public void Valid_DifferentGuidCasing_AreEqual(
+            [Values] SceneType sceneType
+        ) {
+            var guid = sceneType switch
+            {
+                SceneType.NotInBuild => TestUtils.NotInBuildSceneGuid,
+                SceneType.Disabled => TestUtils.DisabledSceneGuid,
+                SceneType.Enabled => TestUtils.EnabledSceneGuid,
+                SceneType.Addressable1 => TestUtils.Addressable1SceneGuid,
+                SceneType.Addressable2 => TestUtils.Addressable2SceneGuid,
+                SceneType.AddressableDuplicateAddressA => TestUtils.AddressableDuplicateAddressASceneGuid,
+                SceneType.AddressableDuplicateAddressB => TestUtils.AddressableDuplicateAddressBSceneGuid,
+                _ => throw new ArgumentOutOfRangeException(nameof(sceneType), sceneType, null),
+            };
+
+            var srLower = new SceneReference(guid);
+            var srUpper = new SceneReference(guid.ToUpperInvariant());
+
+            AssertEquality(true, srLower, srUpper);
+        }
+
         private SceneReference CreateValid(SceneType sceneType, ConceptionType conceptionType)
         {
             var guid = sceneType switch

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/EqualityAndHashCode/SceneReferenceHashCodeTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/EqualityAndHashCode/SceneReferenceHashCodeTests.cs
@@ -46,6 +46,28 @@ namespace Eflatun.SceneReference.Tests.Runtime.EqualityAndHashCode
         }
 
         [Test]
+        public void Valid_DifferentGuidCasing_SameHashCode(
+            [Values] SceneType sceneType
+        ) {
+            var guid = sceneType switch
+            {
+                SceneType.NotInBuild => TestUtils.NotInBuildSceneGuid,
+                SceneType.Disabled => TestUtils.DisabledSceneGuid,
+                SceneType.Enabled => TestUtils.EnabledSceneGuid,
+                SceneType.Addressable1 => TestUtils.Addressable1SceneGuid,
+                SceneType.Addressable2 => TestUtils.Addressable2SceneGuid,
+                SceneType.AddressableDuplicateAddressA => TestUtils.AddressableDuplicateAddressASceneGuid,
+                SceneType.AddressableDuplicateAddressB => TestUtils.AddressableDuplicateAddressBSceneGuid,
+                _ => throw new ArgumentOutOfRangeException(nameof(sceneType), sceneType, null),
+            };
+
+            var srLower = new SceneReference(guid);
+            var srUpper = new SceneReference(guid.ToUpperInvariant());
+
+            Assert.AreEqual(srLower.GetHashCode(), srUpper.GetHashCode());
+        }
+
+        [Test]
         public void Invalid(
             [Values] ConceptionType conceptionType,
             [Values] InvalidReason invalidReason

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/RuntimeUtilsTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/RuntimeUtilsTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Eflatun.SceneReference.Tests.Runtime.Utils;
 using Eflatun.SceneReference.Utility;
 using NUnit.Framework;
@@ -106,24 +105,6 @@ namespace Eflatun.SceneReference.Tests.Runtime
         public void IsAddressablesPackagePresent_Works()
         {
             Assert.AreEqual(TestUtils.IsAddressablesPackagePresent, Eflatun.SceneReference.Utility.Utils.IsAddressablesPackagePresent);
-        }
-
-        [Test]
-        public void ToDictionary_WithComparer_PreservesComparer()
-        {
-            var source = new Dictionary<string, string>
-            {
-                {"abc", "value1"},
-                {"def", "value2"},
-            };
-            IReadOnlyDictionary<string, string> readOnly = source;
-
-            var result = readOnly.ToDictionary(StringComparer.OrdinalIgnoreCase);
-
-            Assert.IsTrue(result.ContainsKey("ABC"));
-            Assert.AreEqual("value1", result["ABC"]);
-            Assert.IsTrue(result.ContainsKey("DEF"));
-            Assert.AreEqual("value2", result["DEF"]);
         }
     }
 }

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/RuntimeUtilsTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/RuntimeUtilsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Eflatun.SceneReference.Tests.Runtime.Utils;
 using Eflatun.SceneReference.Utility;
 using NUnit.Framework;
@@ -105,6 +106,24 @@ namespace Eflatun.SceneReference.Tests.Runtime
         public void IsAddressablesPackagePresent_Works()
         {
             Assert.AreEqual(TestUtils.IsAddressablesPackagePresent, Eflatun.SceneReference.Utility.Utils.IsAddressablesPackagePresent);
+        }
+
+        [Test]
+        public void ToDictionary_WithComparer_PreservesComparer()
+        {
+            var source = new Dictionary<string, string>
+            {
+                {"abc", "value1"},
+                {"def", "value2"},
+            };
+            IReadOnlyDictionary<string, string> readOnly = source;
+
+            var result = readOnly.ToDictionary(StringComparer.OrdinalIgnoreCase);
+
+            Assert.IsTrue(result.ContainsKey("ABC"));
+            Assert.AreEqual("value1", result["ABC"]);
+            Assert.IsTrue(result.ContainsKey("DEF"));
+            Assert.AreEqual("value2", result["DEF"]);
         }
     }
 }

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToAddressMapProviderTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToAddressMapProviderTests.cs
@@ -1,4 +1,5 @@
-﻿using Eflatun.SceneReference.Exceptions;
+﻿using System;
+using Eflatun.SceneReference.Exceptions;
 using Eflatun.SceneReference.Tests.Runtime.Utils;
 using Eflatun.SceneReference.Utility;
 using NUnit.Framework;
@@ -12,9 +13,9 @@ namespace Eflatun.SceneReference.Tests.Runtime
         public void FillWith_Works()
         {
             // cleanup
-            var toRestore = SceneGuidToAddressMapProvider.SceneGuidToAddressMap.ToDictionary();
+            var toRestore = SceneGuidToAddressMapProvider.SceneGuidToAddressMap.ToDictionary(StringComparer.OrdinalIgnoreCase);
 
-            var expected = new Dictionary<string, string>()
+            var expected = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 {"foo", "a"},
                 {"bar", "b"},

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToAddressMapProviderTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToAddressMapProviderTests.cs
@@ -29,6 +29,28 @@ namespace Eflatun.SceneReference.Tests.Runtime
         }
 
         [Test]
+        public void FillWith_PreservesCaseInsensitiveLookup()
+        {
+            // cleanup
+            var toRestore = SceneGuidToAddressMapProvider.SceneGuidToAddressMap.ToDictionary(StringComparer.OrdinalIgnoreCase);
+
+            var input = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                {"abcdef01234567890abcdef012345678", "Address A"},
+                {"11111111222222223333333344444444", "Address B"},
+            };
+            SceneGuidToAddressMapProvider.FillWith(input);
+
+            Assert.IsTrue(SceneGuidToAddressMapProvider.SceneGuidToAddressMap.ContainsKey("ABCDEF01234567890ABCDEF012345678"));
+            Assert.AreEqual("Address A", SceneGuidToAddressMapProvider.SceneGuidToAddressMap["ABCDEF01234567890ABCDEF012345678"]);
+
+            Assert.IsTrue(SceneGuidToAddressMapProvider.SceneGuidToAddressMap.ContainsKey("11111111222222223333333344444444"));
+
+            // cleanup
+            SceneGuidToAddressMapProvider.FillWith(toRestore);
+        }
+
+        [Test]
         public void SceneGuidToAddressMap_ContainsSubjectScenes_WithAddressableSupport()
         {
             TestUtils.IgnoreIfAddressablesSupportIsDisabled();
@@ -38,6 +60,20 @@ namespace Eflatun.SceneReference.Tests.Runtime
 
             Assert.IsTrue(SceneGuidToAddressMapProvider.SceneGuidToAddressMap.ContainsKey(TestUtils.Addressable2SceneGuid));
             Assert.AreEqual(TestUtils.Addressable2SceneAddress, SceneGuidToAddressMapProvider.SceneGuidToAddressMap[TestUtils.Addressable2SceneGuid]);
+        }
+
+        [Test]
+        public void SceneGuidToAddressMap_LookupIsCaseInsensitive_WithAddressableSupport()
+        {
+            TestUtils.IgnoreIfAddressablesSupportIsDisabled();
+
+            var upperAddr1 = TestUtils.Addressable1SceneGuid.ToUpperInvariant();
+            Assert.IsTrue(SceneGuidToAddressMapProvider.SceneGuidToAddressMap.ContainsKey(upperAddr1));
+            Assert.AreEqual(TestUtils.Addressable1SceneAddress, SceneGuidToAddressMapProvider.SceneGuidToAddressMap[upperAddr1]);
+
+            var upperAddr2 = TestUtils.Addressable2SceneGuid.ToUpperInvariant();
+            Assert.IsTrue(SceneGuidToAddressMapProvider.SceneGuidToAddressMap.ContainsKey(upperAddr2));
+            Assert.AreEqual(TestUtils.Addressable2SceneAddress, SceneGuidToAddressMapProvider.SceneGuidToAddressMap[upperAddr2]);
         }
 
         [Test]

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToAddressMapProviderTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToAddressMapProviderTests.cs
@@ -29,28 +29,6 @@ namespace Eflatun.SceneReference.Tests.Runtime
         }
 
         [Test]
-        public void FillWith_PreservesCaseInsensitiveLookup()
-        {
-            // cleanup
-            var toRestore = SceneGuidToAddressMapProvider.SceneGuidToAddressMap.ToDictionary(StringComparer.OrdinalIgnoreCase);
-
-            var input = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                {"abcdef01234567890abcdef012345678", "Address A"},
-                {"11111111222222223333333344444444", "Address B"},
-            };
-            SceneGuidToAddressMapProvider.FillWith(input);
-
-            Assert.IsTrue(SceneGuidToAddressMapProvider.SceneGuidToAddressMap.ContainsKey("ABCDEF01234567890ABCDEF012345678"));
-            Assert.AreEqual("Address A", SceneGuidToAddressMapProvider.SceneGuidToAddressMap["ABCDEF01234567890ABCDEF012345678"]);
-
-            Assert.IsTrue(SceneGuidToAddressMapProvider.SceneGuidToAddressMap.ContainsKey("11111111222222223333333344444444"));
-
-            // cleanup
-            SceneGuidToAddressMapProvider.FillWith(toRestore);
-        }
-
-        [Test]
         public void SceneGuidToAddressMap_ContainsSubjectScenes_WithAddressableSupport()
         {
             TestUtils.IgnoreIfAddressablesSupportIsDisabled();

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToPathMapProviderTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToPathMapProviderTests.cs
@@ -86,28 +86,6 @@ namespace Eflatun.SceneReference.Tests.Runtime
         }
 
         [Test]
-        public void FillWith_PreservesCaseInsensitiveLookup()
-        {
-            // cleanup
-            var toRestore = SceneGuidToPathMapProvider.SceneGuidToPathMap.ToDictionary(StringComparer.OrdinalIgnoreCase);
-
-            var input = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                {"abcdef01234567890abcdef012345678", "Assets/Scenes/Lower.unity"},
-                {"11111111222222223333333344444444", "Assets/Scenes/Other.unity"},
-            };
-            SceneGuidToPathMapProvider.FillWith(input);
-
-            Assert.IsTrue(SceneGuidToPathMapProvider.SceneGuidToPathMap.ContainsKey("ABCDEF01234567890ABCDEF012345678"));
-            Assert.AreEqual("Assets/Scenes/Lower.unity", SceneGuidToPathMapProvider.SceneGuidToPathMap["ABCDEF01234567890ABCDEF012345678"]);
-
-            Assert.IsTrue(SceneGuidToPathMapProvider.SceneGuidToPathMap.ContainsKey("11111111222222223333333344444444"));
-
-            // cleanup
-            SceneGuidToPathMapProvider.FillWith(toRestore);
-        }
-
-        [Test]
         public void SceneGuidToPathMap_And_ScenePathToGuidMap_AreEquivalent()
         {
             var g2p = SceneGuidToPathMapProvider.SceneGuidToPathMap;

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToPathMapProviderTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToPathMapProviderTests.cs
@@ -70,6 +70,44 @@ namespace Eflatun.SceneReference.Tests.Runtime
         }
 
         [Test]
+        public void SceneGuidToPathMap_LookupIsCaseInsensitive()
+        {
+            var upperEnabled = TestUtils.EnabledSceneGuid.ToUpperInvariant();
+            Assert.IsTrue(SceneGuidToPathMapProvider.SceneGuidToPathMap.ContainsKey(upperEnabled));
+            Assert.AreEqual(TestUtils.EnabledScenePath, SceneGuidToPathMapProvider.SceneGuidToPathMap[upperEnabled]);
+
+            var upperDisabled = TestUtils.DisabledSceneGuid.ToUpperInvariant();
+            Assert.IsTrue(SceneGuidToPathMapProvider.SceneGuidToPathMap.ContainsKey(upperDisabled));
+            Assert.AreEqual(TestUtils.DisabledScenePath, SceneGuidToPathMapProvider.SceneGuidToPathMap[upperDisabled]);
+
+            var upperNotInBuild = TestUtils.NotInBuildSceneGuid.ToUpperInvariant();
+            Assert.IsTrue(SceneGuidToPathMapProvider.SceneGuidToPathMap.ContainsKey(upperNotInBuild));
+            Assert.AreEqual(TestUtils.NotInBuildScenePath, SceneGuidToPathMapProvider.SceneGuidToPathMap[upperNotInBuild]);
+        }
+
+        [Test]
+        public void FillWith_PreservesCaseInsensitiveLookup()
+        {
+            // cleanup
+            var toRestore = SceneGuidToPathMapProvider.SceneGuidToPathMap.ToDictionary(StringComparer.OrdinalIgnoreCase);
+
+            var input = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                {"abcdef01234567890abcdef012345678", "Assets/Scenes/Lower.unity"},
+                {"11111111222222223333333344444444", "Assets/Scenes/Other.unity"},
+            };
+            SceneGuidToPathMapProvider.FillWith(input);
+
+            Assert.IsTrue(SceneGuidToPathMapProvider.SceneGuidToPathMap.ContainsKey("ABCDEF01234567890ABCDEF012345678"));
+            Assert.AreEqual("Assets/Scenes/Lower.unity", SceneGuidToPathMapProvider.SceneGuidToPathMap["ABCDEF01234567890ABCDEF012345678"]);
+
+            Assert.IsTrue(SceneGuidToPathMapProvider.SceneGuidToPathMap.ContainsKey("11111111222222223333333344444444"));
+
+            // cleanup
+            SceneGuidToPathMapProvider.FillWith(toRestore);
+        }
+
+        [Test]
         public void SceneGuidToPathMap_And_ScenePathToGuidMap_AreEquivalent()
         {
             var g2p = SceneGuidToPathMapProvider.SceneGuidToPathMap;

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToPathMapProviderTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/SceneGuidToPathMapProviderTests.cs
@@ -1,4 +1,5 @@
-﻿using Eflatun.SceneReference.Tests.Runtime.Utils;
+﻿using System;
+using Eflatun.SceneReference.Tests.Runtime.Utils;
 using Eflatun.SceneReference.Utility;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -53,9 +54,9 @@ namespace Eflatun.SceneReference.Tests.Runtime
         public void FillWith_Works()
         {
             // cleanup
-            var toRestore = SceneGuidToPathMapProvider.SceneGuidToPathMap.ToDictionary();
+            var toRestore = SceneGuidToPathMapProvider.SceneGuidToPathMap.ToDictionary(StringComparer.OrdinalIgnoreCase);
 
-            var expected = new Dictionary<string, string>()
+            var expected = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 {"foo", "a"},
                 {"bar", "b"},

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/SceneReferenceCustomSerializationInCodeCreationTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/SceneReferenceCustomSerializationInCodeCreationTests.cs
@@ -463,5 +463,77 @@ namespace Eflatun.SceneReference.Tests.Runtime
             var deserialized = TestUtils.DeserializeViaSystemXml(xml);
             TestUtils.AssertAddressableDuplicateAddressBSceneState(deserialized);
         }
+
+        [Test]
+        public void DeserializesViaNewtonsoftJson_UppercaseGuid_EnabledScene()
+        {
+            var json = TestUtils.GetExpectedOutputOfNewtonsoftJson(TestUtils.EnabledSceneGuid.ToUpperInvariant());
+            var deserialized = TestUtils.DeserializeViaNewtonsoftJson(json);
+            TestUtils.AssertEnabledSceneState(deserialized);
+        }
+
+        [Test]
+        public void DeserializesViaBinaryFormatter_UppercaseGuid_EnabledScene()
+        {
+            var base64 = TestUtils.GetAsBase64ExpectedOutputOfBinaryFormatter(TestUtils.EnabledSceneGuid.ToUpperInvariant());
+            var deserialized = TestUtils.DeserializeFromBase64ViaBinaryFormatter(base64);
+            TestUtils.AssertEnabledSceneState(deserialized);
+        }
+
+        [Test]
+        public void DeserializesViaSystemXml_UppercaseGuid_EnabledScene()
+        {
+            var xml = TestUtils.GetExpectedOutputOfSystemXml(TestUtils.EnabledSceneGuid.ToUpperInvariant());
+            var deserialized = TestUtils.DeserializeViaSystemXml(xml);
+            TestUtils.AssertEnabledSceneState(deserialized);
+        }
+
+        [Test]
+        public void DeserializesViaNewtonsoftJson_UppercaseGuid_DisabledScene()
+        {
+            var json = TestUtils.GetExpectedOutputOfNewtonsoftJson(TestUtils.DisabledSceneGuid.ToUpperInvariant());
+            var deserialized = TestUtils.DeserializeViaNewtonsoftJson(json);
+            TestUtils.AssertDisabledSceneState(deserialized);
+        }
+
+        [Test]
+        public void DeserializesViaBinaryFormatter_UppercaseGuid_DisabledScene()
+        {
+            var base64 = TestUtils.GetAsBase64ExpectedOutputOfBinaryFormatter(TestUtils.DisabledSceneGuid.ToUpperInvariant());
+            var deserialized = TestUtils.DeserializeFromBase64ViaBinaryFormatter(base64);
+            TestUtils.AssertDisabledSceneState(deserialized);
+        }
+
+        [Test]
+        public void DeserializesViaSystemXml_UppercaseGuid_DisabledScene()
+        {
+            var xml = TestUtils.GetExpectedOutputOfSystemXml(TestUtils.DisabledSceneGuid.ToUpperInvariant());
+            var deserialized = TestUtils.DeserializeViaSystemXml(xml);
+            TestUtils.AssertDisabledSceneState(deserialized);
+        }
+
+        [Test]
+        public void DeserializesViaNewtonsoftJson_UppercaseGuid_NotInBuildScene()
+        {
+            var json = TestUtils.GetExpectedOutputOfNewtonsoftJson(TestUtils.NotInBuildSceneGuid.ToUpperInvariant());
+            var deserialized = TestUtils.DeserializeViaNewtonsoftJson(json);
+            TestUtils.AssertNotInBuildSceneState(deserialized);
+        }
+
+        [Test]
+        public void DeserializesViaBinaryFormatter_UppercaseGuid_NotInBuildScene()
+        {
+            var base64 = TestUtils.GetAsBase64ExpectedOutputOfBinaryFormatter(TestUtils.NotInBuildSceneGuid.ToUpperInvariant());
+            var deserialized = TestUtils.DeserializeFromBase64ViaBinaryFormatter(base64);
+            TestUtils.AssertNotInBuildSceneState(deserialized);
+        }
+
+        [Test]
+        public void DeserializesViaSystemXml_UppercaseGuid_NotInBuildScene()
+        {
+            var xml = TestUtils.GetExpectedOutputOfSystemXml(TestUtils.NotInBuildSceneGuid.ToUpperInvariant());
+            var deserialized = TestUtils.DeserializeViaSystemXml(xml);
+            TestUtils.AssertNotInBuildSceneState(deserialized);
+        }
     }
 }

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/SceneReferenceInCodeCreationTests.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/SceneReferenceInCodeCreationTests.cs
@@ -28,6 +28,19 @@ namespace Eflatun.SceneReference.Tests.Runtime
         }
 
         [Test]
+        public void GuidConstructor_ProvidesExpectedState_WithUppercaseGuid()
+        {
+            var enabledRef = new SceneReference(TestUtils.EnabledSceneGuid.ToUpperInvariant());
+            TestUtils.AssertEnabledSceneState(enabledRef);
+
+            var disabledRef = new SceneReference(TestUtils.DisabledSceneGuid.ToUpperInvariant());
+            TestUtils.AssertDisabledSceneState(disabledRef);
+
+            var notInBuildRef = new SceneReference(TestUtils.NotInBuildSceneGuid.ToUpperInvariant());
+            TestUtils.AssertNotInBuildSceneState(notInBuildRef);
+        }
+
+        [Test]
         public void GuidConstructor_ThrowsForInvalidArguments()
         {
             Assert.Throws<SceneReferenceCreationException>(() => _ = new SceneReference((string)null));

--- a/Eflatun.SceneReference/Assets/Tests/Runtime/Utils/TestUtils.cs
+++ b/Eflatun.SceneReference/Assets/Tests/Runtime/Utils/TestUtils.cs
@@ -101,8 +101,8 @@ namespace Eflatun.SceneReference.Tests.Runtime.Utils
             Assert.IsTrue(couldGetBuildIndex);
             Assert.AreEqual(EnabledSceneBuildIndex, buildIndex);
 
-            Assert.AreEqual(EnabledSceneGuid, sr.Guid);
-            Assert.AreEqual(EnabledSceneGuid, sr.guid);
+            StringAssert.AreEqualIgnoringCase(EnabledSceneGuid, sr.Guid);
+            StringAssert.AreEqualIgnoringCase(EnabledSceneGuid, sr.guid);
             Assert.AreEqual(SceneReferenceState.Regular, sr.State);
             Assert.AreEqual(SceneReferenceUnsafeReason.None, sr.UnsafeReason);
 
@@ -145,8 +145,8 @@ namespace Eflatun.SceneReference.Tests.Runtime.Utils
             Assert.IsTrue(couldGetBuildIndex);
             Assert.AreEqual(DisabledSceneBuildIndex, buildIndex);
 
-            Assert.AreEqual(DisabledSceneGuid, sr.Guid);
-            Assert.AreEqual(DisabledSceneGuid, sr.guid);
+            StringAssert.AreEqualIgnoringCase(DisabledSceneGuid, sr.Guid);
+            StringAssert.AreEqualIgnoringCase(DisabledSceneGuid, sr.guid);
 
 // TODO: Unity seems to be enabling all scenes before making a test build.
 // Figure out a way to disable that behaviour and then get rid of this define check.
@@ -197,8 +197,8 @@ namespace Eflatun.SceneReference.Tests.Runtime.Utils
             Assert.IsTrue(couldGetBuildIndex);
             Assert.AreEqual(NotInBuildSceneBuildIndex, buildIndex);
 
-            Assert.AreEqual(NotInBuildSceneGuid, sr.Guid);
-            Assert.AreEqual(NotInBuildSceneGuid, sr.guid);
+            StringAssert.AreEqualIgnoringCase(NotInBuildSceneGuid, sr.Guid);
+            StringAssert.AreEqualIgnoringCase(NotInBuildSceneGuid, sr.guid);
             Assert.AreEqual(SceneReferenceState.Unsafe, sr.State);
             Assert.AreEqual(SceneReferenceUnsafeReason.NotInBuild, sr.UnsafeReason);
 
@@ -241,8 +241,8 @@ namespace Eflatun.SceneReference.Tests.Runtime.Utils
             Assert.IsFalse(couldGetBuildIndex);
             Assert.AreEqual(-1, buildIndex);
 
-            Assert.AreEqual(AllZeroGuid, sr.Guid);
-            Assert.AreEqual(AllZeroGuid, sr.guid);
+            StringAssert.AreEqualIgnoringCase(AllZeroGuid, sr.Guid);
+            StringAssert.AreEqualIgnoringCase(AllZeroGuid, sr.guid);
             Assert.AreEqual(SceneReferenceState.Unsafe, sr.State);
             Assert.AreEqual(SceneReferenceUnsafeReason.Empty, sr.UnsafeReason);
 
@@ -291,8 +291,8 @@ namespace Eflatun.SceneReference.Tests.Runtime.Utils
             Assert.IsFalse(couldGetBuildIndex);
             Assert.AreEqual(-1, buildIndex);
 
-            Assert.AreEqual(expectedGuid, sr.Guid);
-            Assert.AreEqual(expectedGuid, sr.guid);
+            StringAssert.AreEqualIgnoringCase(expectedGuid, sr.Guid);
+            StringAssert.AreEqualIgnoringCase(expectedGuid, sr.guid);
             Assert.AreEqual(SceneReferenceState.Unsafe, sr.State);
             Assert.AreEqual(SceneReferenceUnsafeReason.NotInMaps, sr.UnsafeReason);
 
@@ -343,8 +343,8 @@ namespace Eflatun.SceneReference.Tests.Runtime.Utils
             Assert.IsTrue(couldGetBuildIndex);
             Assert.AreEqual(-1, buildIndex);
 
-            Assert.AreEqual(expectedGuid, sr.Guid);
-            Assert.AreEqual(expectedGuid, sr.guid);
+            StringAssert.AreEqualIgnoringCase(expectedGuid, sr.Guid);
+            StringAssert.AreEqualIgnoringCase(expectedGuid, sr.guid);
 
             if (IsAddressablesPackagePresent)
             {

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneDataMapsGenerator.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneDataMapsGenerator.cs
@@ -1,4 +1,5 @@
-﻿using Eflatun.SceneReference.Editor.Utility;
+﻿using System;
+using Eflatun.SceneReference.Editor.Utility;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using System.Collections.Generic;
@@ -80,7 +81,8 @@ namespace Eflatun.SceneReference.Editor
         {
             var sceneGuidToPathMap = allSceneGuids.ToDictionary(
                 x => x, // key generator: take guids
-                AssetDatabase.GUIDToAssetPath // value generator: take paths
+                AssetDatabase.GUIDToAssetPath, // value generator: take paths
+                StringComparer.OrdinalIgnoreCase
             );
             return sceneGuidToPathMap;
         }
@@ -104,7 +106,7 @@ namespace Eflatun.SceneReference.Editor
             if (!AddressableAssetSettingsDefaultObject.SettingsExists)
             {
                 EditorLogger.Warn("Addressables settings not found. Skipping map generation.");
-                return new Dictionary<string, string>();
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
 
             var addressableSettings = AddressableAssetSettingsDefaultObject.Settings;
@@ -115,12 +117,13 @@ namespace Eflatun.SceneReference.Editor
 
             var sceneGuidToAddressMap = addressableSceneAssetEntries.ToDictionary(
                 x => x.guid, // key generator: take guids
-                x => x.address // value generator: take addresses
+                x => x.address, // value generator: take addresses
+                StringComparer.OrdinalIgnoreCase
             );
 
             return sceneGuidToAddressMap;
 #else // ESR_ADDRESSABLES
-            return new Dictionary<string, string>();
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 #endif // ESR_ADDRESSABLES
         }
 

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SceneReferencePropertyDrawer.cs
@@ -81,7 +81,7 @@ namespace Eflatun.SceneReference.Editor
             _asset = _assetSerializedProperty.objectReferenceValue;
             _guid = _guidSerializedProperty.stringValue;
             _path = AssetDatabase.GetAssetPath(_asset);
-            _buildEntry = EditorBuildSettings.scenes.FirstOrDefault(x => x.guid.ToString() == _guid);
+            _buildEntry = EditorBuildSettings.scenes.FirstOrDefault(x => StringComparer.OrdinalIgnoreCase.Equals(x.guid.ToString(), _guid));
 
 #if ESR_ADDRESSABLES
             if (AddressableAssetSettingsDefaultObject.SettingsExists)

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SettingsManager.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/SettingsManager.cs
@@ -337,7 +337,7 @@ namespace Eflatun.SceneReference.Editor
             internal static bool IsIgnoredForToolbox(string path, string guid) => ToolboxIgnoreMode.value switch
             {
                 UtilityIgnoreMode.Disabled => false,
-                UtilityIgnoreMode.List => ToolboxIgnoresList.value.Contains(guid),
+                UtilityIgnoreMode.List => ToolboxIgnoresList.value.Contains(guid, StringComparer.OrdinalIgnoreCase),
                 UtilityIgnoreMode.Patterns => IgnoreCheckers.Toolbox.IsIgnored(path),
                 _ => throw new ArgumentOutOfRangeException()
             };
@@ -345,7 +345,7 @@ namespace Eflatun.SceneReference.Editor
             internal static bool IsIgnoredForColoring(string path, string guid) => ColoringIgnoreMode.value switch
             {
                 UtilityIgnoreMode.Disabled => false,
-                UtilityIgnoreMode.List => ColoringIgnoresList.value.Contains(guid),
+                UtilityIgnoreMode.List => ColoringIgnoresList.value.Contains(guid, StringComparer.OrdinalIgnoreCase),
                 UtilityIgnoreMode.Patterns => IgnoreCheckers.Coloring.IsIgnored(path),
                 _ => throw new ArgumentOutOfRangeException()
             };

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/Utility/EditorUtils.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Editor/Utility/EditorUtils.cs
@@ -75,7 +75,7 @@ namespace Eflatun.SceneReference.Editor.Utility
         public static void EnableSceneInBuild(string sceneGuid)
         {
             var tempScenes = EditorBuildSettings.scenes.ToList();
-            tempScenes.Single(x => x.guid.ToString() == sceneGuid).enabled = true;
+            tempScenes.Single(x => StringComparer.OrdinalIgnoreCase.Equals(x.guid.ToString(), sceneGuid)).enabled = true;
             EditorBuildSettings.scenes = tempScenes.ToArray();
         }
 

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneGuidToAddressMapProvider.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneGuidToAddressMapProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using Eflatun.SceneReference.Exceptions;
 using JetBrains.Annotations;
 using System.Collections.Generic;
@@ -130,14 +131,15 @@ namespace Eflatun.SceneReference
             if (string.IsNullOrWhiteSpace(json))
             {
                 Logger.Error("Scene GUID to address map not found!");
-                FillWith(new Dictionary<string, string>());
+                FillWith(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
                 return;
             }
 
-            var deserialized = JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
+            var deserialized = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            JsonConvert.PopulateObject(json, deserialized);
             FillWith(deserialized);
 #else // ESR_ADDRESSABLES
-            FillWith(new Dictionary<string, string>());
+            FillWith(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 #endif // ESR_ADDRESSABLES
         }
     }

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneGuidToPathMapProvider.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneGuidToPathMapProvider.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;
@@ -88,11 +89,12 @@ namespace Eflatun.SceneReference
                     Logger.Error("Scene GUID to path map not found!");
                 }
 
-                FillWith(new Dictionary<string, string>());
+                FillWith(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
                 return;
             }
 
-            var deserialized = JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
+            var deserialized = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            JsonConvert.PopulateObject(json, deserialized);
             FillWith(deserialized);
         }
     }

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneReference.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/SceneReference.cs
@@ -226,7 +226,8 @@ namespace Eflatun.SceneReference
                     throw SceneReferenceInternalException.InvalidGuid("54783205", Guid);
                 }
 
-                return Guid != Utils.AllZeroGuid;
+                // AllZeroGuid is all zeros, casing is irrelevant. The only reason we are using OrdinalIgnoreCase here is consistency.
+                return !StringComparer.OrdinalIgnoreCase.Equals(Guid, Utils.AllZeroGuid);
             }
         }
 

--- a/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/Utility/Utils.cs
+++ b/Eflatun.SceneReference/Packages/com.eflatun.scenereference/Runtime/Utility/Utils.cs
@@ -97,13 +97,13 @@ namespace Eflatun.SceneReference.Utility
         /// <summary>
         /// Convert <see cref="IReadOnlyDictionary{TKey, TValue}"/> to <see cref="Dictionary{TKey, TValue}"/>.
         /// </summary>
-        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> readOnly)
+        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> readOnly, IEqualityComparer<TKey> comparer)
         {
 // Backwards compatibility: Dictionary did not have a constructor that took in an IReadOnlyDictionary for Unity versions before 2021.3.
 #if UNITY_2021_3_OR_NEWER
-            return new Dictionary<TKey, TValue>(readOnly);
+            return new Dictionary<TKey, TValue>(readOnly, comparer);
 #else
-            return readOnly.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            return readOnly.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, comparer);
 #endif
         }
     }


### PR DESCRIPTION
Follows up from the case-insensitive GUID comparison logic implemented in PR #120 for issue #112.
Temporary alternative solution to the problem the issue #121 would solve implicitly.